### PR TITLE
6.14-GE-2 Release

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = proton-ge-custom-bin
 	pkgdesc = A fancy custom distribution of Valves Proton with various patches
-	pkgver = 6.14_GE_1
+	pkgver = 6.14_GE_2
 	pkgrel = 0
 	url = https://github.com/GloriousEggroll/proton-ge-custom
 	changelog = changelog
@@ -27,14 +27,14 @@ pkgbase = proton-ge-custom-bin
 	optdepends = xboxdrv: gamepad driver service
 	optdepends = python-cef: generic splash dialog support
 	provides = proton
-	provides = proton-ge-custom=6.14.GE_1
+	provides = proton-ge-custom=6.14.GE_2
 	conflicts = proton-ge-custom-stable-bin
 	conflicts = proton-ge-custom
 	options = !strip
 	backup = usr/share/steam/compatibilitytools.d/proton-ge-custom/user_settings.py
-	source = proton-ge-custom-6.14-GE-1_0.tar.gz::https://github.com/GloriousEggroll/proton-ge-custom/releases/download/6.14-GE-1/Proton-6.14-GE-1.tar.gz
+	source = proton-ge-custom-6.14-GE-2_0.tar.gz::https://github.com/GloriousEggroll/proton-ge-custom/releases/download/6.14-GE-2/Proton-6.14-GE-2.tar.gz
 	source = supplementary.tar.zst
-	sha512sums = bfe9a9dc73d65fd98a169ef03aeee4ee8b8939b6afaa09fb58c21f4df8b1055993184c8af47f96d628d6a9f08f3200a54f2709cdc5f57c46ddc29c2802bd9a8e
+	sha512sums = 26b8be360652dafe69f5c4d0599bf40a0890e6ae59469a08f6096f9029521572cdeb1229315d9b7bc91b7b8ca13b460d3df641b4b0f5178d8093ab7bad06fe1f
 	sha512sums = 9925a9972a9bed9b9e71c2aa169db03eeb72307336c3ed004434397deb379b55eb13b249ca9c0b28f48dd5ea728a1ad32685b84e2dcab881ba428c2acb7bc58d
 
 pkgname = proton-ge-custom-bin

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@
 ## pkginfo
 pkgdesc="A fancy custom distribution of Valves Proton with various patches"
 pkgname=proton-ge-custom-bin
-pkgver=6.14_GE_1
+pkgver=6.14_GE_2
 pkgrel=0
 arch=('x86_64')
 license=('BSD' 'LGPL' 'zlib' 'MIT' 'MPL' 'custom')
@@ -49,7 +49,7 @@ backup=("${_protoncfg}")
 url='https://github.com/GloriousEggroll/proton-ge-custom'
 source=(${_pkgname}-${_pkgver}_${pkgrel}.tar.gz::"${url}/releases/download/${_pkgver}/${_srcdir}.tar.gz"
         "supplementary.tar.zst")
-sha512sums=('bfe9a9dc73d65fd98a169ef03aeee4ee8b8939b6afaa09fb58c21f4df8b1055993184c8af47f96d628d6a9f08f3200a54f2709cdc5f57c46ddc29c2802bd9a8e'
+sha512sums=('26b8be360652dafe69f5c4d0599bf40a0890e6ae59469a08f6096f9029521572cdeb1229315d9b7bc91b7b8ca13b460d3df641b4b0f5178d8093ab7bad06fe1f'
             '9925a9972a9bed9b9e71c2aa169db03eeb72307336c3ed004434397deb379b55eb13b249ca9c0b28f48dd5ea728a1ad32685b84e2dcab881ba428c2acb7bc58d')
 
 build() {


### PR DESCRIPTION
Looks like upstream will create a new release, instead of reusing the same version for hotfixes. See: https://github.com/GloriousEggroll/proton-ge-custom/releases/tag/6.14-GE-2