### PR TITLE
Change internal and display name of compatibility tool to a fixed one.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -55,6 +55,7 @@ sha512sums=('df00907475c4cfed8e23c4d9c3f716b478ea3b20b6bd4d222e5308ae657f9b61939
 build() {
 ## setup paths
 sed -i "s|_proton=echo|_proton=/${_protondir}/proton|" ${srcdir}/launchers/proton.sh
+sed -i -r 's|"Proton-.*"|"Proton-GE"|' ${srcdir}/Proton-${_pkgver}/compatibilitytool.vdf
 }
 
 package() {


### PR DESCRIPTION
Having the name change between versions break steam and force the user to reconfigure steam in non obvious way.