### PR TITLE
Bump version to 6.21_GE_2

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = proton-ge-custom-bin
 	pkgdesc = A fancy custom distribution of Valves Proton with various patches
-	pkgver = 6.21_GE_1
+	pkgver = 6.21_GE_2
 	pkgrel = 1
 	url = https://github.com/GloriousEggroll/proton-ge-custom
 	changelog = changelog
@@ -27,14 +27,14 @@ pkgbase = proton-ge-custom-bin
 	optdepends = xboxdrv: gamepad driver service
 	optdepends = python-cef: generic splash dialog support
 	provides = proton
-	provides = proton-ge-custom=6.21.GE_1
+	provides = proton-ge-custom=6.21.GE_2
 	conflicts = proton-ge-custom-stable-bin
 	conflicts = proton-ge-custom
 	options = !strip
 	backup = usr/share/steam/compatibilitytools.d/proton-ge-custom/user_settings.py
-	source = proton-ge-custom-6.21-GE-1_1.tar.gz::https://github.com/GloriousEggroll/proton-ge-custom/releases/download/6.21-GE-1/Proton-6.21-GE-1.tar.gz
+	source = proton-ge-custom-6.21-GE-2_1.tar.gz::https://github.com/GloriousEggroll/proton-ge-custom/releases/download/6.21-GE-2/Proton-6.21-GE-2.tar.gz
 	source = supplementary.tar.zst
-	sha512sums = df00907475c4cfed8e23c4d9c3f716b478ea3b20b6bd4d222e5308ae657f9b61939b906c5ec5f3aac7d048334850078ec0bb9dab1bfd1a8bb6b66fd05ff95673
+	sha512sums = 8204a1340ce8af39ead2596ece489b924fb46c112bffda51dff04b314c86676a5a718b9c66fc72313259f1c69bc49800e36a999834620176ca91a3d67cafcdb1
 	sha512sums = 9925a9972a9bed9b9e71c2aa169db03eeb72307336c3ed004434397deb379b55eb13b249ca9c0b28f48dd5ea728a1ad32685b84e2dcab881ba428c2acb7bc58d
 
 pkgname = proton-ge-custom-bin

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -5,7 +5,7 @@
 ## pkginfo
 pkgdesc="A fancy custom distribution of Valves Proton with various patches"
 pkgname=proton-ge-custom-bin
-pkgver=6.21_GE_1
+pkgver=6.21_GE_2
 pkgrel=1
 arch=('x86_64')
 license=('BSD' 'LGPL' 'zlib' 'MIT' 'MPL' 'custom')
@@ -49,7 +49,7 @@ backup=("${_protoncfg}")
 url='https://github.com/GloriousEggroll/proton-ge-custom'
 source=(${_pkgname}-${_pkgver}_${pkgrel}.tar.gz::"${url}/releases/download/${_pkgver}/${_srcdir}.tar.gz"
         "supplementary.tar.zst")
-sha512sums=('df00907475c4cfed8e23c4d9c3f716b478ea3b20b6bd4d222e5308ae657f9b61939b906c5ec5f3aac7d048334850078ec0bb9dab1bfd1a8bb6b66fd05ff95673'
+sha512sums=('8204a1340ce8af39ead2596ece489b924fb46c112bffda51dff04b314c86676a5a718b9c66fc72313259f1c69bc49800e36a999834620176ca91a3d67cafcdb1'
             '9925a9972a9bed9b9e71c2aa169db03eeb72307336c3ed004434397deb379b55eb13b249ca9c0b28f48dd5ea728a1ad32685b84e2dcab881ba428c2acb7bc58d')
 
 build() {


### PR DESCRIPTION
GE_2 released to prevent people from launching Destiny 2 and getting banned. This is just a version bump to that.