### PR TITLE
upgpkg: GE_Proton10_1-2: add wayland and hdr to user_settings.py

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = proton-ge-custom-bin
 	pkgdesc = A fancy custom distribution of Valves Proton with various patches
 	pkgver = GE_Proton10_1
-	pkgrel = 1
+	pkgrel = 2
 	epoch = 1
 	url = https://github.com/GloriousEggroll/proton-ge-custom
 	install = pleasenote.install
@@ -47,12 +47,12 @@ pkgbase = proton-ge-custom-bin
 	options = !strip
 	options = emptydirs
 	backup = usr/share/steam/compatibilitytools.d/proton-ge-custom/user_settings.py
-	source = GE-Proton10-1_1.tar.gz::https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton10-1/GE-Proton10-1.tar.gz
+	source = GE-Proton10-1_2.tar.gz::https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton10-1/GE-Proton10-1.tar.gz
 	source = user_settings.py
 	source = launcher.sh
 	source = pam_limits.conf
 	sha512sums = 43beaf2c07090d7cb0817436d5c0862caf7265462d2efbbecbf5361f5f2601a9edcf52f159bfc823028c835be982a9d17c170beccbc1e722c770e7f62bf90f42
-	sha512sums = babe2a461118bef6a777656a10bb89abeee2c8c3ed4285eb1b99f5ba517b779f18372d1d93ed2cce63b0d8111cf0b08e14a0c92435680239f6936783c3e4cbc5
+	sha512sums = 7c1a535d6dc33dbcd9de5605d4ec5b3cd38096d0d09de31c46037b3cbbbac8d4d64c24709b487ba3bd343eddae2b53d4f7b83559193381c09bc5961b9d7d75c2
 	sha512sums = 78ede6d50f9c43407da511c8b37dcf60aae2ddbd461c0081f0d0ce3de08ace3a84dee86e9253acbac829b47c5818ef4e1a354ccb05feaa9853ce279dc3f903fd
 	sha512sums = 60bcb1ad899d108fca9c6267321d11871feae96b696e44607ef533becc6decb493e93cbe699382e8163ad83f35cfa003a059499c37278f31afeba4700be6e356
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,7 +12,7 @@
 pkgdesc='A fancy custom distribution of Valves Proton with various patches'
 pkgname=proton-ge-custom-bin
 pkgver=GE_Proton10_1
-pkgrel=1
+pkgrel=2
 epoch=1
 arch=('x86_64')
 license=('BSD' 'LGPL' 'zlib' 'MIT' 'MPL' 'custom')
@@ -78,7 +78,7 @@ source=("${_pkgver}_${pkgrel}.tar.gz::${url}/releases/download/${_pkgver}/${_pkg
   'launcher.sh'
   'pam_limits.conf')
 sha512sums=('43beaf2c07090d7cb0817436d5c0862caf7265462d2efbbecbf5361f5f2601a9edcf52f159bfc823028c835be982a9d17c170beccbc1e722c770e7f62bf90f42'
-            'babe2a461118bef6a777656a10bb89abeee2c8c3ed4285eb1b99f5ba517b779f18372d1d93ed2cce63b0d8111cf0b08e14a0c92435680239f6936783c3e4cbc5'
+            '7c1a535d6dc33dbcd9de5605d4ec5b3cd38096d0d09de31c46037b3cbbbac8d4d64c24709b487ba3bd343eddae2b53d4f7b83559193381c09bc5961b9d7d75c2'
             '78ede6d50f9c43407da511c8b37dcf60aae2ddbd461c0081f0d0ce3de08ace3a84dee86e9253acbac829b47c5818ef4e1a354ccb05feaa9853ce279dc3f903fd'
             '60bcb1ad899d108fca9c6267321d11871feae96b696e44607ef533becc6decb493e93cbe699382e8163ad83f35cfa003a059499c37278f31afeba4700be6e356')
 

--- a/user_settings.py
+++ b/user_settings.py
@@ -23,6 +23,12 @@ user_settings = {
 
     ###### Proton flags ######
 
+    #Enable Wayland display output. Games running with native Vulkan and OpenGL may have problems. Required for HDR support
+#   "PROTON_ENABLE_WAYLAND": "1",
+
+    #Enable HDR support. Requires Wayland to be enabled and for HDR to be enabled in system settings.
+#   "PROTON_ENABLE_HDR":    "1",
+
     #Convenience method for dumping a useful debug log to $PROTON_LOG_DIR/steam-$APPID.log
 #    "PROTON_LOG": "1",
 


### PR DESCRIPTION
Proton 10.1 has introduced native Wayland and HDR support for games. I think those settings are important enough to be added to `user_settings.py`.

Also, I think this PR should be a starting point to update `user_settings.py`, as it seems like it hasn't been updated in 2 years. The current proton options can be found [here](https://github.com/GloriousEggroll/proton-ge-custom/blob/master/proton) around line 1710.