### PR TITLE
chore: upgrade to 10-3

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = proton-ge-custom-bin
 	pkgdesc = A fancy custom distribution of Valves Proton with various patches
-	pkgver = GE_Proton10_2
+	pkgver = GE_Proton10_3
 	pkgrel = 1
 	epoch = 1
 	url = https://github.com/GloriousEggroll/proton-ge-custom
@@ -42,16 +42,16 @@ pkgbase = proton-ge-custom-bin
 	optdepends = wine: support for 32bit prefixes
 	optdepends = xboxdrv: gamepad driver service
 	provides = proton
-	provides = proton-ge-custom=GE.Proton10_2
+	provides = proton-ge-custom=GE.Proton10_3
 	conflicts = proton-ge-custom
 	options = !strip
 	options = emptydirs
 	backup = usr/share/steam/compatibilitytools.d/proton-ge-custom/user_settings.py
-	source = GE-Proton10-2_1.tar.gz::https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton10-2/GE-Proton10-2.tar.gz
+	source = GE-Proton10-3_1.tar.gz::https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton10-3/GE-Proton10-3.tar.gz
 	source = user_settings.py
 	source = launcher.sh
 	source = pam_limits.conf
-	sha512sums = 1c47a541f9790f94061ca0488b9588016dc124d811fd06ce09aea80c750544c2efc4b9b498398626195d3f2912055a55df3570d8418f7677b0979f1d01fc851e
+	sha512sums = a7224e033beeb64b088cb43d2c1e8aa654cea39bc18b185d55960a00ebf9e93aabcd29e06444dc8aa1e416ea4a461dbac6ea8bbfca017a4abe87ffc50b8bc1c1
 	sha512sums = 7c1a535d6dc33dbcd9de5605d4ec5b3cd38096d0d09de31c46037b3cbbbac8d4d64c24709b487ba3bd343eddae2b53d4f7b83559193381c09bc5961b9d7d75c2
 	sha512sums = 78ede6d50f9c43407da511c8b37dcf60aae2ddbd461c0081f0d0ce3de08ace3a84dee86e9253acbac829b47c5818ef4e1a354ccb05feaa9853ce279dc3f903fd
 	sha512sums = 60bcb1ad899d108fca9c6267321d11871feae96b696e44607ef533becc6decb493e93cbe699382e8163ad83f35cfa003a059499c37278f31afeba4700be6e356

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,7 +11,7 @@
 ## pkginfo
 pkgdesc='A fancy custom distribution of Valves Proton with various patches'
 pkgname=proton-ge-custom-bin
-pkgver=GE_Proton10_2
+pkgver=GE_Proton10_3
 pkgrel=1
 epoch=1
 arch=('x86_64')
@@ -69,7 +69,7 @@ _execfile=usr/bin/proton
 _protoncfg=${_protondir}/user_settings.py
 
 ## user edited files to backup
-backup=("${_protoncfg}")
+backup=("$_protoncfg")
 
 ## sources
 url='https://github.com/GloriousEggroll/proton-ge-custom'
@@ -77,33 +77,33 @@ source=("${_pkgver}_${pkgrel}.tar.gz::${url}/releases/download/${_pkgver}/${_pkg
   'user_settings.py'
   'launcher.sh'
   'pam_limits.conf')
-sha512sums=('1c47a541f9790f94061ca0488b9588016dc124d811fd06ce09aea80c750544c2efc4b9b498398626195d3f2912055a55df3570d8418f7677b0979f1d01fc851e'
+sha512sums=('a7224e033beeb64b088cb43d2c1e8aa654cea39bc18b185d55960a00ebf9e93aabcd29e06444dc8aa1e416ea4a461dbac6ea8bbfca017a4abe87ffc50b8bc1c1'
             '7c1a535d6dc33dbcd9de5605d4ec5b3cd38096d0d09de31c46037b3cbbbac8d4d64c24709b487ba3bd343eddae2b53d4f7b83559193381c09bc5961b9d7d75c2'
             '78ede6d50f9c43407da511c8b37dcf60aae2ddbd461c0081f0d0ce3de08ace3a84dee86e9253acbac829b47c5818ef4e1a354ccb05feaa9853ce279dc3f903fd'
             '60bcb1ad899d108fca9c6267321d11871feae96b696e44607ef533becc6decb493e93cbe699382e8163ad83f35cfa003a059499c37278f31afeba4700be6e356')
 
 build() {
   ## patches
-  sed -i "s|_proton=echo|_proton=/${_protondir}/proton|" "${srcdir}"/launcher.sh
-  sed -i -r 's|"GE-Proton.*"|"Proton-GE"|' "${_srcdir}"/compatibilitytool.vdf
+  sed -i "s|_proton=echo|_proton=/${_protondir}/proton|" "$srcdir"/launcher.sh
+  sed -i -r 's|"GE-Proton.*"|"Proton-GE"|' "$_srcdir"/compatibilitytool.vdf
   ## fixes from namcap inspection
-  strip --preserve-dates --strip-unneeded "${_srcdir}"/files/bin/wine*
+  strip --preserve-dates --strip-unneeded "$_srcdir"/files/bin/wine*
 }
 
 package() {
   ## create paths
   install -d "${pkgdir}/${_protondir}/"
   install -d "${pkgdir}/${_licensedir}/"
-  install -d "${pkgdir}/$(dirname ${_execfile})/"
+  install -d "${pkgdir}/$(dirname "$_execfile")/"
   install -d "${pkgdir}/etc/security/limits.d/"
   ## licenses
   mv "${_srcdir}/LICENSE" "${pkgdir}/${_licensedir}/license"
   mv "${_srcdir}/LICENSE.OFL" "${pkgdir}/${_licensedir}/license_OFL"
   mv "${_srcdir}/PATENTS.AV1" "${pkgdir}/${_licensedir}/license_AV1"
   ## config files
-  install --mode=0775 --group=50 "${srcdir}"/user_settings.py "${pkgdir}/${_protoncfg}"
-  install --mode=0644 "${srcdir}"/pam_limits.conf "${pkgdir}"/etc/security/limits.d/10-games.conf
+  install --mode=0775 --group=50 "$srcdir"/user_settings.py "${pkgdir}/${_protoncfg}"
+  install --mode=0644 "$srcdir"/pam_limits.conf "$pkgdir"/etc/security/limits.d/10-games.conf
   ## executables
-  mv "${_srcdir}"/* "${pkgdir}/${_protondir}"
-  install --mode=0755 "${srcdir}"/launcher.sh "${pkgdir}/${_execfile}"
+  mv "$_srcdir"/* "${pkgdir}/${_protondir}"
+  install --mode=0755 "$srcdir"/launcher.sh "${pkgdir}/${_execfile}"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -84,26 +84,26 @@ sha512sums=('a7224e033beeb64b088cb43d2c1e8aa654cea39bc18b185d55960a00ebf9e93aabc
 
 build() {
   ## patches
-  sed -i "s|_proton=echo|_proton=/${_protondir}/proton|" "$srcdir"/launcher.sh
-  sed -i -r 's|"GE-Proton.*"|"Proton-GE"|' "$_srcdir"/compatibilitytool.vdf
+  sed -i "s|_proton=echo|_proton=/${_protondir}/proton|" "${srcdir}"/launcher.sh
+  sed -i -r 's|"GE-Proton.*"|"Proton-GE"|' "${_srcdir}"/compatibilitytool.vdf
   ## fixes from namcap inspection
-  strip --preserve-dates --strip-unneeded "$_srcdir"/files/bin/wine*
+  strip --preserve-dates --strip-unneeded "${_srcdir}"/files/bin/wine*
 }
 
 package() {
   ## create paths
   install -d "${pkgdir}/${_protondir}/"
   install -d "${pkgdir}/${_licensedir}/"
-  install -d "${pkgdir}/$(dirname "$_execfile")/"
+  install -d "${pkgdir}/$(dirname "${_execfile}")/"
   install -d "${pkgdir}/etc/security/limits.d/"
   ## licenses
   mv "${_srcdir}/LICENSE" "${pkgdir}/${_licensedir}/license"
   mv "${_srcdir}/LICENSE.OFL" "${pkgdir}/${_licensedir}/license_OFL"
   mv "${_srcdir}/PATENTS.AV1" "${pkgdir}/${_licensedir}/license_AV1"
   ## config files
-  install --mode=0775 --group=50 "$srcdir"/user_settings.py "${pkgdir}/${_protoncfg}"
-  install --mode=0644 "$srcdir"/pam_limits.conf "$pkgdir"/etc/security/limits.d/10-games.conf
+  install --mode=0775 --group=50 "${srcdir}"/user_settings.py "${pkgdir}/${_protoncfg}"
+  install --mode=0644 "${srcdir}"/pam_limits.conf "${pkgdir}"/etc/security/limits.d/10-games.conf
   ## executables
-  mv "$_srcdir"/* "${pkgdir}/${_protondir}"
-  install --mode=0755 "$srcdir"/launcher.sh "${pkgdir}/${_execfile}"
+  mv "${_srcdir}"/* "${pkgdir}/${_protondir}"
+  install --mode=0755 "${srcdir}"/launcher.sh "${pkgdir}/${_execfile}"
 }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+## GE-Proton10-3
+
+Hotfix release:
+- added envvar needed for winewayland patch fixes to work (automatically set when PROTON_ENABLE_WAYLAND is set)
+- added patch so that PROTON_ENABLE/DISABLE_HIDRAW works as expected.
+
+Important note:
+PLEASE do NOT manually set `DISPLAY=` when trying to enable winewayland. ALL that is needed is PROTON_ENABLE_WAYLAND=1. When you manually disable DISPLAY= it can break many applications that need to render natively, in particular things like launchers or things that need to render with OpenGL or Vulkan directly. (not via dxvk/vkd3d).
+
 ## GE-Proton10-2
 
 Hotfix release:


### PR DESCRIPTION
Hotfix release:
- added envvar needed for winewayland patch fixes to work (automatically set when PROTON_ENABLE_WAYLAND is set)
- added patch so that PROTON_ENABLE/DISABLE_HIDRAW works as expected.

Important note:
PLEASE do NOT manually set `DISPLAY=` when trying to enable winewayland. ALL that is needed is PROTON_ENABLE_WAYLAND=1. When you manually disable DISPLAY= it can break many applications that need to render natively, in particular things like launchers or things that need to render with OpenGL or Vulkan directly. (not via dxvk/vkd3d).
