### PR TITLE
upgpkg: GE_Proton10_9-2: add PROTON_USE_WOW64 to user_settings.py

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = proton-ge-custom-bin
 	pkgdesc = A fancy custom distribution of Valves Proton with various patches
 	pkgver = GE_Proton10_9
-	pkgrel = 1
+	pkgrel = 2
 	epoch = 1
 	url = https://github.com/GloriousEggroll/proton-ge-custom
 	install = pleasenote.install
@@ -47,12 +47,12 @@ pkgbase = proton-ge-custom-bin
 	options = !strip
 	options = emptydirs
 	backup = usr/share/steam/compatibilitytools.d/proton-ge-custom/user_settings.py
-	source = GE-Proton10-9_1.tar.gz::https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton10-9/GE-Proton10-9.tar.gz
+	source = GE-Proton10-9_2.tar.gz::https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton10-9/GE-Proton10-9.tar.gz
 	source = user_settings.py
 	source = launcher.sh
 	source = pam_limits.conf
 	sha512sums = d5ce1989a827b8589d0ee4380b846755a9c6278307dd4fb7ca9ff966d360a4f44876c796ffdb2008ace9e99660f902804b3d68f36256b55f6b22e8a2933b6980
-	sha512sums = 71a63ac577b557cce2b5b095ba452fd3abbcb0438cddd5cf97a765e97dce7bc2a84e9cca7d9683eaea84c3c396369aa98b457a2deb17986d3da729b58a86e205
+	sha512sums = 4b9828471cbbafd6d4e88e150cfa86d7a16755d3c97cf4c5c0201d3e08d996a06e5c432b3f7a6335c6a6daa7ca0ee3b8552757c204824be51a3a8d6b2dc61b1c
 	sha512sums = 78ede6d50f9c43407da511c8b37dcf60aae2ddbd461c0081f0d0ce3de08ace3a84dee86e9253acbac829b47c5818ef4e1a354ccb05feaa9853ce279dc3f903fd
 	sha512sums = 60bcb1ad899d108fca9c6267321d11871feae96b696e44607ef533becc6decb493e93cbe699382e8163ad83f35cfa003a059499c37278f31afeba4700be6e356
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,7 +12,7 @@
 pkgdesc='A fancy custom distribution of Valves Proton with various patches'
 pkgname=proton-ge-custom-bin
 pkgver=GE_Proton10_9
-pkgrel=1
+pkgrel=2
 epoch=1
 arch=('x86_64')
 license=('BSD' 'LGPL' 'zlib' 'MIT' 'MPL' 'custom')
@@ -78,7 +78,7 @@ source=("${_pkgver}_${pkgrel}.tar.gz::${url}/releases/download/${_pkgver}/${_pkg
   'launcher.sh'
   'pam_limits.conf')
 sha512sums=('d5ce1989a827b8589d0ee4380b846755a9c6278307dd4fb7ca9ff966d360a4f44876c796ffdb2008ace9e99660f902804b3d68f36256b55f6b22e8a2933b6980'
-            '71a63ac577b557cce2b5b095ba452fd3abbcb0438cddd5cf97a765e97dce7bc2a84e9cca7d9683eaea84c3c396369aa98b457a2deb17986d3da729b58a86e205'
+            '4b9828471cbbafd6d4e88e150cfa86d7a16755d3c97cf4c5c0201d3e08d996a06e5c432b3f7a6335c6a6daa7ca0ee3b8552757c204824be51a3a8d6b2dc61b1c'
             '78ede6d50f9c43407da511c8b37dcf60aae2ddbd461c0081f0d0ce3de08ace3a84dee86e9253acbac829b47c5818ef4e1a354ccb05feaa9853ce279dc3f903fd'
             '60bcb1ad899d108fca9c6267321d11871feae96b696e44607ef533becc6decb493e93cbe699382e8163ad83f35cfa003a059499c37278f31afeba4700be6e356')
 

--- a/user_settings.py
+++ b/user_settings.py
@@ -26,6 +26,9 @@ user_settings = {
     #Enable use of the ntsync kernel driver to improve performance and compatibility of Windows NT synchronization primitives.
 #   "PROTON_USE_NTSYNC": "1",
 
+    #Enable WoW64 Mode For Wine Prefixes. Required for Ntsync use with 32-bit games
+#   "PROTON_USE_WOW64": "1",
+
     #Enable automatic upgrading of AMD FidelityFX Super Resolution (FSR) to FSR4.
 #   "PROTON_FSR4_UPGRADE": "1",
 


### PR DESCRIPTION
`PROTON_USE_WOW64` is required for Ntsync to work with 32bit games, as listed in the [release notes](https://github.com/GloriousEggroll/proton-ge-custom/releases/tag/GE-Proton10-9) for GE-Proton10-9.