### PR TITLE
Update niceness limit files

### DIFF
--- a/pam_limits.conf
+++ b/pam_limits.conf
@@ -1,1 +1,1 @@
-@games - nice -11
+@games - nice -10

--- a/pleasenote.install
+++ b/pleasenote.install
@@ -1,10 +1,12 @@
 post_install() {
-    ## Wine wants to adjust niceness of a process up to -10. It will complain if RLIMIT_NICE will not allow this.
-    ## Since niceness is limited to 0 by default on arch, we make this work with pam login by setting nice limit to -10 for users in group games.
-    ## See file /etc/security/limits.d/10-games.conf.
+    ## Wine wants to adjust niceness of a process up to -10. It will complain if RLIMIT_NICE does not allow this.
+    ## Since niceness is limited to 0 by default on Arch, we make this work with PAM Login by setting niceness limit to -10 for users in the "games" group.
+    ## See file "/etc/security/limits.d/10-games.conf".
     echo ""
-    echo "The wine executable used by proton can automatically set the niceness of a process;"
-    echo "Consider adding yourself to the games group to make this work by issuing: usermod -a -G games"
+    echo "The Wine executable used by Proton can automatically set the niceness of processes."
+    echo "Consider adding yourself to the \"games\" group to make this work:
+    echo ""
+    echo "# gpasswd -a \$(whoami) games"
     echo ""
 }
 


### PR DESCRIPTION
- Updates "pleasenote.install" with some misc. comment changes, plus updates the command used to add user to group by a new one preferred by the ArchWiki (see https://wiki.archlinux.org/title/Users_and_groups#Group_management ).
- Updates niceness limit to -10 instead of -11 to match the comment which states -10 as the value. -10 is the value used by Feral Interactive gamemode utility ( https://github.com/FeralInteractive/gamemode/blob/master/data/pam_limits/10-gamemode.conf.in ), although Proton uses -15 as an example ( https://github.com/ValveSoftware/Proton/blob/bleeding-edge/docs/THREAD_PRIORITY.md ).